### PR TITLE
OFS-180: Fix error when creating CD on just created Contract

### DIFF
--- a/src/components/ContractForm.js
+++ b/src/components/ContractForm.js
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from "react";
-import { Form, withModulesManager, formatMessage, formatMessageWithValues, journalize } from "@openimis/fe-core";
+import { Form, withModulesManager, formatMessage, formatMessageWithValues, journalize, decodeId } from "@openimis/fe-core";
 import { Fab, Tooltip } from "@material-ui/core";
 import { injectIntl } from "react-intl";
 import { bindActionCreators } from "redux";
@@ -54,7 +54,7 @@ class ContractForm extends Component {
             this.props.journalize(this.props.mutation);
             this.props.fetchContract(
                 this.props.modulesManager,
-                !!this.props.contractId ? [`id: "${this.props.contractId}"`] : [`clientMutationId: "${this.props.mutation.clientMutationId}"`]
+                !!this.state.contract.id ? [`id: "${decodeId(this.state.contract.id)}"`] : [`clientMutationId: "${this.props.mutation.clientMutationId}"`]
             );
         }
     }

--- a/src/components/ContractTabPanel.js
+++ b/src/components/ContractTabPanel.js
@@ -2,9 +2,6 @@ import React from "react";
 import { Paper, Grid } from "@material-ui/core";
 import { withModulesManager, FormPanel, Contributions } from "@openimis/fe-core";
 import { injectIntl } from "react-intl";
-import { bindActionCreators } from "redux";
-import { connect } from "react-redux";
-import {  } from "../actions"
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { RIGHT_POLICYHOLDERCONTRACT_UPDATE, RIGHT_POLICYHOLDERCONTRACT_APPROVE, CONTRACTDETAILS_TAB_VALUE } from "../constants"
 
@@ -71,8 +68,4 @@ class ContractTabPanel extends FormPanel {
     }
 }
 
-const mapDispatchToProps = dispatch => {
-    return bindActionCreators({  }, dispatch);
-};
-
-export default withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(null, mapDispatchToProps)(ContractTabPanel)))));
+export default withModulesManager(injectIntl(withTheme(withStyles(styles)(ContractTabPanel))));


### PR DESCRIPTION
When a new Contract has just been created, its `id` is available in `state` but not yet in `props` as the update page has not been accessed from Contracts page. Therefore to successfully refetch Contract after creating Contract Details, `id` from `state` has to be used.