### PR TITLE
OFS-180: Fix error when creating CD on just created Contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ None
 
 ## Other Modules Redux State Bindings
 * `state.core.user`, to access user info (rights,...)
-* `state.policyHolder`, retrieving Policy Holder Insurees to auto complete Contribution Plan Bundle when creating Contract Details
+* `state.policyHolder`, retrieving Policy Holder to fetch corresponding Policy Holder Contribution Plan Bundles and Policy Holder Insurees
 
 ## Configurations Options
 * `contractFilter.contractStateOptions`: options for ContractStatePicker component (Default:

--- a/src/components/ContractDetailsFilter.js
+++ b/src/components/ContractDetailsFilter.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import { injectIntl } from 'react-intl';
+import { connect } from "react-redux";
 import { withModulesManager, formatMessage, TextInput, PublishedComponent, decodeId } from "@openimis/fe-core";
 import { Grid } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
@@ -21,7 +22,7 @@ class ContractDetailsFilter extends Component {
     }
 
     render() {
-        const { intl, classes, filters, onChangeFilters } = this.props;
+        const { intl, classes, onChangeFilters, policyHolder } = this.props;
         return (
             <Grid container className={classes.form}>
                 <Grid item xs={3} className={classes.item}>
@@ -41,7 +42,7 @@ class ContractDetailsFilter extends Component {
                         pubRef="policyHolder.PolicyHolderContributionPlanBundlePicker"
                         withNull
                         nullLabel={formatMessage(intl, "contract", "any")}
-                        policyHolderId={!!filters['policyHolder_Id'] && filters['policyHolder_Id'].value}
+                        policyHolderId={!!policyHolder && decodeId(policyHolder.id)}
                         value={this._filterValue('contributionPlanBundle_Id')}
                         onChange={v => onChangeFilters([{
                             id: 'contributionPlanBundle_Id',
@@ -55,4 +56,8 @@ class ContractDetailsFilter extends Component {
     }
 }
 
-export default withModulesManager(injectIntl(withTheme(withStyles(styles)(ContractDetailsFilter))));
+const mapStateToProps = state => ({
+    policyHolder: !!state.contract.contract ? state.contract.contract.policyHolder : null
+});
+
+export default withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(mapStateToProps, null)((ContractDetailsFilter))))));

--- a/src/components/ContractDetailsSearcher.js
+++ b/src/components/ContractDetailsSearcher.js
@@ -83,20 +83,12 @@ class ContractDetailsSearcher extends Component {
     }
 
     defaultFilters = () => {
-        const { contract } = this.props;
-        let filters = {
+        return {
             contract_Id: {
-                value: decodeId(contract.id),
-                filter: `contract_Id: "${decodeId(contract.id)}"`
+                value: decodeId(this.props.contract.id),
+                filter: `contract_Id: "${decodeId(this.props.contract.id)}"`
             }
         };
-        if (!!contract.policyHolder) {
-            filters.policyHolder_Id = {
-                value: decodeId(contract.policyHolder.id),
-                filter: `contract_PolicyHolder_Id: "${decodeId(contract.policyHolder.id)}"`
-            };
-        }
-        return filters;
     }
 
     render() {

--- a/src/components/ContractForm.js
+++ b/src/components/ContractForm.js
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from "react";
-import { Form, withModulesManager, formatMessage, formatMessageWithValues, journalize } from "@openimis/fe-core";
+import { Form, withModulesManager, formatMessage, formatMessageWithValues, journalize, decodeId } from "@openimis/fe-core";
 import { Fab, Tooltip } from "@material-ui/core";
 import { injectIntl } from "react-intl";
 import { bindActionCreators } from "redux";
@@ -54,7 +54,7 @@ class ContractForm extends Component {
             this.props.journalize(this.props.mutation);
             this.props.fetchContract(
                 this.props.modulesManager,
-                !!this.props.contractId ? [`id: "${this.props.contractId}"`] : [`clientMutationId: "${this.props.mutation.clientMutationId}"`]
+                !!this.state.contract.id ? [`id: "${decodeId(this.state.contract.id)}"`] : [`clientMutationId: "${this.props.mutation.clientMutationId}"`]
             );
         }
     }

--- a/src/components/ContractTabPanel.js
+++ b/src/components/ContractTabPanel.js
@@ -2,9 +2,6 @@ import React from "react";
 import { Paper, Grid } from "@material-ui/core";
 import { withModulesManager, FormPanel, Contributions } from "@openimis/fe-core";
 import { injectIntl } from "react-intl";
-import { bindActionCreators } from "redux";
-import { connect } from "react-redux";
-import {  } from "../actions"
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { RIGHT_POLICYHOLDERCONTRACT_UPDATE, RIGHT_POLICYHOLDERCONTRACT_APPROVE, CONTRACTDETAILS_TAB_VALUE } from "../constants"
 
@@ -71,8 +68,4 @@ class ContractTabPanel extends FormPanel {
     }
 }
 
-const mapDispatchToProps = dispatch => {
-    return bindActionCreators({  }, dispatch);
-};
-
-export default withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(null, mapDispatchToProps)(ContractTabPanel)))));
+export default withModulesManager(injectIntl(withTheme(withStyles(styles)(ContractTabPanel))));

--- a/src/dialogs/CreateContractDetailsDialog.js
+++ b/src/dialogs/CreateContractDetailsDialog.js
@@ -112,7 +112,7 @@ class CreateContractDetailsDialog extends Component {
                                     pubRef="policyHolder.PolicyHolderInsureePicker"
                                     required
                                     withNull
-                                    policyHolderId={!!contract.policyHolder && contract.policyHolder.id && decodeId(contract.policyHolder.id)}
+                                    policyHolderId={!!contract.policyHolder && decodeId(contract.policyHolder.id)}
                                     value={!!contractDetails.insuree && contractDetails.insuree}
                                     onChange={v => this.updateAttribute('insuree', v)}
                                 />
@@ -122,7 +122,7 @@ class CreateContractDetailsDialog extends Component {
                                     pubRef="policyHolder.PolicyHolderContributionPlanBundlePicker"
                                     withNull
                                     nullLabel={formatMessage(intl, "contract", "emptyLabel")}
-                                    policyHolderId={!!contract.policyHolder && contract.policyHolder.id && decodeId(contract.policyHolder.id)}
+                                    policyHolderId={!!contract.policyHolder && decodeId(contract.policyHolder.id)}
                                     value={!!contractDetails.contributionPlanBundle && contractDetails.contributionPlanBundle}
                                     onChange={v => this.updateAttribute('contributionPlanBundle', v)}
                                     readOnly


### PR DESCRIPTION
When a new Contract has just been created, its id is available in state but not yet in props as the update page has not been accessed from Contracts page. Therefore to successfully refetch Contract after creating Contract Details, id from state has to be used.