### PR TITLE
OFS-180: Disable create new Contract button when Contract is read-only

### DIFF
--- a/src/components/ContractDetailsSearcher.js
+++ b/src/components/ContractDetailsSearcher.js
@@ -7,7 +7,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { IconButton } from "@material-ui/core";
 import DeleteIcon from '@material-ui/icons/Delete';
-import { DEFAULT_PAGE_SIZE, RIGHT_POLICYHOLDERCONTRACT_APPROVE, RIGHT_POLICYHOLDERCONTRACT_UPDATE, ROWS_PER_PAGE_OPTIONS } from "../constants"
+import { DEFAULT_PAGE_SIZE, ROWS_PER_PAGE_OPTIONS } from "../constants"
 import ContractDetailsFilter from "../components/ContractDetailsFilter";
 import UpdateContractDetailsDialog from "../dialogs/UpdateContractDetailsDialog";
 
@@ -87,7 +87,7 @@ class ContractDetailsSearcher extends Component {
                 contract={this.props.contract}
                 contractDetails={contractDetails}
                 onSave={this.props.onSave}
-                disabled={this.state.deleted.includes(contractDetails.id) || !this.isActionEnabled()}
+                disabled={this.state.deleted.includes(contractDetails.id) || !this.props.isActionEnabled}
                 setConfirmedAction={this.props.setConfirmedAction}
             />
         ),
@@ -95,7 +95,7 @@ class ContractDetailsSearcher extends Component {
             <div>
                 <IconButton
                     onClick={() => this.onDelete(contractDetails)}
-                    disabled={this.state.deleted.includes(contractDetails.id) || !this.isActionEnabled()}>
+                    disabled={this.state.deleted.includes(contractDetails.id) || !this.props.isActionEnabled}>
                     <DeleteIcon/>
                 </IconButton>
             </div>,
@@ -133,16 +133,6 @@ class ContractDetailsSearcher extends Component {
             this.setState({ toDelete: contractDetails.id });
         }
         setConfirmedAction(confirm, confirmedAction);
-    }
-
-    isActionEnabled = () => {
-        const { rights, isUpdatable, isApprovable } = this.props;
-        if (rights.includes(RIGHT_POLICYHOLDERCONTRACT_APPROVE)) {
-            return isUpdatable || isApprovable;
-        } else if (rights.includes(RIGHT_POLICYHOLDERCONTRACT_UPDATE)) {
-            return isUpdatable;
-        }
-        return false;
     }
 
     isRowDisabled = (_, contractDetails) => this.state.deleted.includes(contractDetails.id);

--- a/src/components/ContractDetailsTab.js
+++ b/src/components/ContractDetailsTab.js
@@ -36,8 +36,18 @@ class ContractDetailsTabPanel extends Component {
         }));
     }
 
+    isActionEnabled = () => {
+        const { rights, isUpdatable, isApprovable } = this.props;
+        if (rights.includes(RIGHT_POLICYHOLDERCONTRACT_APPROVE)) {
+            return isUpdatable || isApprovable;
+        } else if (rights.includes(RIGHT_POLICYHOLDERCONTRACT_UPDATE)) {
+            return isUpdatable;
+        }
+        return false;
+    }
+
     render() {
-        const { rights, value, isTabsEnabled, contract, setConfirmedAction, isUpdatable, isApprovable } = this.props;
+        const { rights, value, isTabsEnabled, contract, setConfirmedAction } = this.props;
         return (
             (rights.includes(RIGHT_POLICYHOLDERCONTRACT_UPDATE) || rights.includes(RIGHT_POLICYHOLDERCONTRACT_APPROVE)) &&
                 <PublishedComponent
@@ -59,6 +69,7 @@ class ContractDetailsTabPanel extends Component {
                                         contract={contract}
                                         onSave={this.onSave}
                                         setConfirmedAction={setConfirmedAction}
+                                        disabled={!this.isActionEnabled()}
                                     />
                                 </Grid>
                             </Grid>
@@ -68,8 +79,7 @@ class ContractDetailsTabPanel extends Component {
                                 reset={this.state.reset}
                                 onSave={this.onSave}
                                 setConfirmedAction={setConfirmedAction}
-                                isUpdatable={isUpdatable}
-                                isApprovable={isApprovable}
+                                isActionEnabled={this.isActionEnabled()}
                             />
                         </Fragment>
                     ) : (

--- a/src/dialogs/CreateContractDetailsDialog.js
+++ b/src/dialogs/CreateContractDetailsDialog.js
@@ -101,14 +101,15 @@ class CreateContractDetailsDialog extends Component {
     }
 
     render() {
-        const { intl, classes, contract } = this.props;
+        const { intl, classes, contract, disabled } = this.props;
         const { open, contractDetails } = this.state;
         return (
             <Fragment>
                 <Fab
                     size="small"
                     color="primary"
-                    onClick={this.handleOpen}>
+                    onClick={this.handleOpen}
+                    disabled={disabled}>
                     <AddIcon/>
                 </Fab>
                 <Dialog open={open} onClose={this.handleClose}>


### PR DESCRIPTION
`Create new Contract` button has to be disabled if Contract is in an inappropriate state or user has insufficient authorities.