### PR TITLE
OFS-165: Fixing empty amount fields on update page

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3,7 +3,7 @@ import {
 } from "@openimis/fe-core";
 
 const CONTRACT_FULL_PROJECTION = modulesManager => [
-    "id", "code", "amount", "dateApproved", "datePaymentDue",
+    "id", "code", "amount", "amountNotified", "amountRectified", "amountDue", "dateApproved", "datePaymentDue",
     "state", "paymentReference", "amendment", "dateValidFrom", "dateValidTo", "isDeleted",
     "policyHolder" + modulesManager.getProjection("policyHolder.PolicyHolderPicker.projection")
 ];


### PR DESCRIPTION
`Amount Notified`, `Amount Rectified` and `Amount Due` fields appear empty on Contract update page. This is caused by removing `amountNotified`, `amountRectified` and `amountDue` in https://github.com/openimis/openimis-fe-contract_js/pull/27