### PR TITLE
OP-759: fixed double 'front' in url of 'new contract from policyholder page

### DIFF
--- a/src/components/PolicyHolderContractsTab.js
+++ b/src/components/PolicyHolderContractsTab.js
@@ -54,7 +54,8 @@ class RawPolicyHolderContractsTabPanel extends Component {
 
     onCreateButtonClick = () => {
         const { history, policyHolder } = this.props;
-        history.push(`${this.contractCreatePageUrl()}?${QUERY_STRING_POLICYHOLDER}=${decodeId(policyHolder.id)}`);
+        let urlContractPageFromPolicyHolder = `${this.contractCreatePageUrl()}?${QUERY_STRING_POLICYHOLDER}=${decodeId(policyHolder.id)}`;
+        history.push(urlContractPageFromPolicyHolder.replace('front/',''));
     };
 
     onDoubleClick = (contract, newTab = false) => {


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-759

now there shouldn't be the issue with double 'front' after this fix
![Peek 2022-05-06 15-14](https://user-images.githubusercontent.com/52816247/167139916-728ca12f-f82e-40e3-aae3-2d13348ff8de.gif)

