### PR TITLE
OP-968 make policy holder field mandatory

### DIFF
--- a/src/components/ContractForm.js
+++ b/src/components/ContractForm.js
@@ -101,10 +101,7 @@ class ContractForm extends Component {
     isMandatoryFieldsEmpty = () => {
         const { contract } = this.state;
 
-        return !(!!contract.code &&
-            !!contract.policyHolder &&
-            !!contract.dateValidFrom &&
-            !!contract.dateValidTo);
+        return (!contract.code || !contract.policyHolder || !contract.dateValidFrom || !contract.dateValidTo);
     }
 
     canSave = () => !this.isMandatoryFieldsEmpty();

--- a/src/components/ContractForm.js
+++ b/src/components/ContractForm.js
@@ -100,10 +100,11 @@ class ContractForm extends Component {
 
     isMandatoryFieldsEmpty = () => {
         const { contract } = this.state;
-        if (!!contract.code && !!contract.dateValidFrom && !!contract.dateValidTo) {
-            return false;
-        }
-        return true;
+
+        return !(!!contract.code &&
+            !!contract.policyHolder &&
+            !!contract.dateValidFrom &&
+            !!contract.dateValidTo);
     }
 
     canSave = () => !this.isMandatoryFieldsEmpty();

--- a/src/components/ContractHeadPanel.js
+++ b/src/components/ContractHeadPanel.js
@@ -118,6 +118,7 @@ class ContractHeadPanel extends FormPanel {
                             pubRef="policyHolder.PolicyHolderPicker"
                             module="contract"
                             withNull
+                            required
                             nullLabel={formatMessage(intl, "contract", "emptyLabel")}
                             value={!!edited && !!edited.policyHolder && edited.policyHolder}
                             onChange={v => this.updateAttribute('policyHolder', v)}


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OP-968

This PR makes policy holder field in contract tab mandatory and allows to save the contract only if all of the required fields are filled.