### PR TITLE
OTC-909: allow policy holder to be null when displaying contract

### DIFF
--- a/src/components/ContractForm.js
+++ b/src/components/ContractForm.js
@@ -68,10 +68,10 @@ class ContractForm extends Component {
                 (state, props) => ({
                     contract: {
                         ...props.contract,
-                        policyHolder: {
+                        policyHolder: !!props.contract.policyHolder ? {
                             ...props.contract.policyHolder,
                             id: decodeId(props.contract.policyHolder.id)
-                        },
+                        } : null,
                     },
                     reset: state.reset + 1,
                     isDirty: false,


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-909

Now the contract details should display correctly even if the policy holder is null.