### PR TITLE
OTC-757: Clearing pagination state if entered the ContractsPage

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -41,3 +41,5 @@ export const RIGHT_PORTALPAYMENT_SEARCH = 154501
 export const RIGHT_INSUREEPOLICY_SEARCH = 101500
 export const RIGHT_PORTALINSUREEPOLICY_SEARCH = 154901
 export const APPLY_DEFAULT_VALIDITY_FILTER = "applyDefaultValidityFilter";
+export const MODULE_NAME = "contact";
+export const CONTRACT_ROUTE_CONTRACT = "contract.route.contract";

--- a/src/pages/ContractsPage.js
+++ b/src/pages/ContractsPage.js
@@ -17,6 +17,8 @@ import {
   RIGHT_POLICYHOLDERCONTRACT_CREATE,
   RIGHT_POLICYHOLDERCONTRACT_UPDATE,
   RIGHT_POLICYHOLDERCONTRACT_APPROVE,
+  CONTRACT_ROUTE_CONTRACT,
+  MODULE_NAME,
 } from "../constants";
 import ContractSearcher from "../components/ContractSearcher";
 import { Fab } from "@material-ui/core";
@@ -32,11 +34,11 @@ class ContractsPage extends Component {
     historyPush(
       this.props.modulesManager,
       this.props.history,
-      "contract.route.contract"
+      CONTRACT_ROUTE_CONTRACT
     );
 
   contractUpdatePageUrl = (contract) =>
-    `${this.props.modulesManager.getRef("contract.route.contract")}${
+    `${this.props.modulesManager.getRef(CONTRACT_ROUTE_CONTRACT)}${
       "/" + decodeId(contract.id)
     }`;
 
@@ -49,7 +51,7 @@ class ContractsPage extends Component {
       historyPush(
         modulesManager,
         history,
-        "contract.route.contract",
+        CONTRACT_ROUTE_CONTRACT,
         [decodeId(contract.id)],
         newTab
       );
@@ -57,9 +59,8 @@ class ContractsPage extends Component {
   };
 
   componentDidMount = () => {
-    const moduleName = "contact";
     const { module } = this.props;
-    if (module !== moduleName) this.props.clearCurrentPaginationPage();
+    if (module !== MODULE_NAME) this.props.clearCurrentPaginationPage();
   };
 
   render() {

--- a/src/pages/ContractsPage.js
+++ b/src/pages/ContractsPage.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { bindActionCreators } from "redux";
 import {
   Helmet,
   withModulesManager,
@@ -6,6 +7,7 @@ import {
   withTooltip,
   historyPush,
   decodeId,
+  clearCurrentPaginationPage,
 } from "@openimis/fe-core";
 import { injectIntl } from "react-intl";
 import { withTheme, withStyles } from "@material-ui/core/styles";
@@ -54,6 +56,12 @@ class ContractsPage extends Component {
     }
   };
 
+  componentDidMount = () => {
+    const moduleName = "contact";
+    const { module } = this.props;
+    if (module !== moduleName) this.props.clearCurrentPaginationPage();
+  };
+
   render() {
     const { intl, classes, rights } = this.props;
     return (
@@ -91,10 +99,18 @@ const mapStateToProps = (state) => ({
     !!state.core && !!state.core.user && !!state.core.user.i_user
       ? state.core.user.i_user.rights
       : [],
+  module: state.core?.savedPagination?.module,
 });
+
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators({ clearCurrentPaginationPage }, dispatch);
 
 export default withModulesManager(
   injectIntl(
-    withTheme(withStyles(styles)(connect(mapStateToProps, null)(ContractsPage)))
+    withTheme(
+      withStyles(styles)(
+        connect(mapStateToProps, mapDispatchToProps)(ContractsPage)
+      )
+    )
   )
 );

--- a/src/pages/ContractsPage.js
+++ b/src/pages/ContractsPage.js
@@ -1,58 +1,100 @@
 import React, { Component } from "react";
-import { Helmet, withModulesManager, formatMessage, withTooltip, historyPush, decodeId } from "@openimis/fe-core";
+import {
+  Helmet,
+  withModulesManager,
+  formatMessage,
+  withTooltip,
+  historyPush,
+  decodeId,
+} from "@openimis/fe-core";
 import { injectIntl } from "react-intl";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { connect } from "react-redux";
-import { RIGHT_POLICYHOLDERCONTRACT_SEARCH, RIGHT_POLICYHOLDERCONTRACT_CREATE,
-    RIGHT_POLICYHOLDERCONTRACT_UPDATE, RIGHT_POLICYHOLDERCONTRACT_APPROVE } from "../constants"
+import {
+  RIGHT_POLICYHOLDERCONTRACT_SEARCH,
+  RIGHT_POLICYHOLDERCONTRACT_CREATE,
+  RIGHT_POLICYHOLDERCONTRACT_UPDATE,
+  RIGHT_POLICYHOLDERCONTRACT_APPROVE,
+} from "../constants";
 import ContractSearcher from "../components/ContractSearcher";
 import { Fab } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
 
-const styles = theme => ({
-    page: theme.page,
-    fab: theme.fab
-})
-
-class ContractsPage extends Component {
-    onAdd = () => historyPush(this.props.modulesManager, this.props.history, "contract.route.contract");
-
-    contractUpdatePageUrl = contract => `${this.props.modulesManager.getRef("contract.route.contract")}${"/" + decodeId(contract.id)}`;
-
-    onDoubleClick = (contract, newTab = false) => {
-        const { rights, modulesManager, history } = this.props;
-        if (rights.includes(RIGHT_POLICYHOLDERCONTRACT_UPDATE) || rights.includes(RIGHT_POLICYHOLDERCONTRACT_APPROVE)) {
-            historyPush(modulesManager, history, "contract.route.contract", [decodeId(contract.id)], newTab);
-        }
-    }
-    
-    render() {
-        const { intl, classes, rights } = this.props;
-        return (
-            rights.includes(RIGHT_POLICYHOLDERCONTRACT_SEARCH) && (
-                <div className={classes.page}>
-                    <Helmet title={formatMessage(this.props.intl, "contract", "contracts.page.title")} />
-                    <ContractSearcher
-                        onDoubleClick={this.onDoubleClick}
-                        contractUpdatePageUrl={this.contractUpdatePageUrl}
-                        rights={rights}
-                    />
-                    {rights.includes(RIGHT_POLICYHOLDERCONTRACT_CREATE) && withTooltip(
-                        <div className={classes.fab} >
-                            <Fab color="primary" onClick={this.onAdd}>
-                                <AddIcon />
-                            </Fab>
-                        </div>,
-                        formatMessage(intl, "contract", "createButton.tooltip")
-                    )}
-                </div>
-            )
-        )
-    }
-}
-
-const mapStateToProps = state => ({
-    rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : []
+const styles = (theme) => ({
+  page: theme.page,
+  fab: theme.fab,
 });
 
-export default withModulesManager(injectIntl(withTheme(withStyles(styles)(connect(mapStateToProps, null)(ContractsPage)))));
+class ContractsPage extends Component {
+  onAdd = () =>
+    historyPush(
+      this.props.modulesManager,
+      this.props.history,
+      "contract.route.contract"
+    );
+
+  contractUpdatePageUrl = (contract) =>
+    `${this.props.modulesManager.getRef("contract.route.contract")}${
+      "/" + decodeId(contract.id)
+    }`;
+
+  onDoubleClick = (contract, newTab = false) => {
+    const { rights, modulesManager, history } = this.props;
+    if (
+      rights.includes(RIGHT_POLICYHOLDERCONTRACT_UPDATE) ||
+      rights.includes(RIGHT_POLICYHOLDERCONTRACT_APPROVE)
+    ) {
+      historyPush(
+        modulesManager,
+        history,
+        "contract.route.contract",
+        [decodeId(contract.id)],
+        newTab
+      );
+    }
+  };
+
+  render() {
+    const { intl, classes, rights } = this.props;
+    return (
+      rights.includes(RIGHT_POLICYHOLDERCONTRACT_SEARCH) && (
+        <div className={classes.page}>
+          <Helmet
+            title={formatMessage(
+              this.props.intl,
+              "contract",
+              "contracts.page.title"
+            )}
+          />
+          <ContractSearcher
+            onDoubleClick={this.onDoubleClick}
+            contractUpdatePageUrl={this.contractUpdatePageUrl}
+            rights={rights}
+          />
+          {rights.includes(RIGHT_POLICYHOLDERCONTRACT_CREATE) &&
+            withTooltip(
+              <div className={classes.fab}>
+                <Fab color="primary" onClick={this.onAdd}>
+                  <AddIcon />
+                </Fab>
+              </div>,
+              formatMessage(intl, "contract", "createButton.tooltip")
+            )}
+        </div>
+      )
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  rights:
+    !!state.core && !!state.core.user && !!state.core.user.i_user
+      ? state.core.user.i_user.rights
+      : [],
+});
+
+export default withModulesManager(
+  injectIntl(
+    withTheme(withStyles(styles)(connect(mapStateToProps, null)(ContractsPage)))
+  )
+);


### PR DESCRIPTION
[OTC-757](https://openimis.atlassian.net/browse/OTC-757)

Changes:
- Code refactor in ContractsPage.
- Clearing pagination state if entered the ConctractsPage.
- Implementation of the logic responsible for going back from edit form and keeping the same page which was before.

[OTC-757]: https://openimis.atlassian.net/browse/OTC-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ