### PR TITLE
OTC-1085: Revert changes, fix Searchers in contract module

### DIFF
--- a/src/components/ContractContributionDetailsFilter.js
+++ b/src/components/ContractContributionDetailsFilter.js
@@ -18,7 +18,12 @@ const styles = theme => ({
 class ContractContributionDetailsFilter extends Component {
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : "";
+        return !!filters[k] ? filters[k].value : null;
+    }
+
+    _filterTextFieldValue = (key) => {
+        const { filters } = this.props;
+        return !!filters[key] ? filters[key].value : "";
     }
 
     render() {
@@ -29,7 +34,7 @@ class ContractContributionDetailsFilter extends Component {
                     <TextInput
                         module="contract" 
                         label="insureeChfId"
-                        value={this._filterValue('contractDetails_Insuree_ChfId')}
+                        value={this._filterTextFieldValue('contractDetails_Insuree_ChfId')}
                         onChange={v => onChangeFilters([{
                             id: 'contractDetails_Insuree_ChfId',
                             value: v,
@@ -69,6 +74,7 @@ class ContractContributionDetailsFilter extends Component {
                         pubRef="product.ProductPicker"
                         withNull={true}
                         label={formatMessage(intl, "contract", "benefitPlan")}
+                        value={this._filterValue('contributionPlan_BenefitPlan_Id')}
                         onChange={v => onChangeFilters([{
                             id: 'contributionPlan_BenefitPlan_Id',
                             value: v,

--- a/src/components/ContractDetailsFilter.js
+++ b/src/components/ContractDetailsFilter.js
@@ -18,7 +18,12 @@ const styles = theme => ({
 class ContractDetailsFilter extends Component {
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : "";
+        return !!filters[k] ? filters[k].value : null;
+    }
+
+    _filterTextFieldValue = (key) => {
+        const { filters } = this.props;
+        return !!filters[key] ? filters[key].value : "";
     }
 
     render() {
@@ -29,7 +34,7 @@ class ContractDetailsFilter extends Component {
                     <TextInput
                         module="contract" 
                         label="insureeChfId"
-                        value={this._filterValue('insuree_ChfId')}
+                        value={this._filterTextFieldValue('insuree_ChfId')}
                         onChange={v => onChangeFilters([{
                             id: 'insuree_ChfId',
                             value: v,

--- a/src/components/ContractFilter.js
+++ b/src/components/ContractFilter.js
@@ -27,7 +27,12 @@ class ContractFilter extends Component {
 
     _filterValue = k => {
         const { filters } = this.props;
-        return !!filters[k] ? filters[k].value : "";
+        return !!filters[k] ? filters[k].value : null;
+    }
+
+    _filterTextFieldValue = (key) => {
+        const { filters } = this.props;
+        return !!filters[key] ? filters[key].value : "";
     }
 
     _onChangeFilter = (k, v) => {
@@ -68,7 +73,7 @@ class ContractFilter extends Component {
                     <TextInput
                         module="contract"
                         label="code"
-                        value={this._filterValue('code')}
+                        value={this._filterTextFieldValue('code')}
                         onChange={v => this._onChangeStringFilter('code', v, CONTAINS_LOOKUP)}
                     />
                 </Grid>
@@ -139,7 +144,7 @@ class ContractFilter extends Component {
                     <TextInput
                         module="contract"
                         label="paymentReference"
-                        value={this._filterValue('paymentReference')}
+                        value={this._filterTextFieldValue('paymentReference')}
                         onChange={v => this._onChangeStringFilter('paymentReference', v, CONTAINS_LOOKUP)}
                     />
                 </Grid>


### PR DESCRIPTION
[OTC-1085](https://openimis.atlassian.net/browse/OTC-1085)

Changes:
- Revert of [previous PR](https://github.com/openimis/openimis-fe-contract_js/pull/54). I realised that previous change could cause issues with other pickers. I decided to revert it and implement a new, more reliable solution.
- Clearing search criterias using "Reset button" fixed.

[OTC-1085]: https://openimis.atlassian.net/browse/OTC-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ