### PR TITLE
OP-1725: remove null/empty option from dropdowns

### DIFF
--- a/src/components/ContractHeadPanel.js
+++ b/src/components/ContractHeadPanel.js
@@ -174,8 +174,7 @@ class ContractHeadPanel extends FormPanel {
             <PublishedComponent
               pubRef="policyHolder.PolicyHolderPicker"
               module="contract"
-              withNull
-              nullLabel={formatMessage(intl, "contract", "emptyLabel")}
+              withNull={false}
               value={!!edited && !!edited.policyHolder && edited.policyHolder}
               onChange={(v) => this.updateAttribute("policyHolder", v)}
               readOnly={

--- a/src/dialogs/CreateContractDetailsDialog.js
+++ b/src/dialogs/CreateContractDetailsDialog.js
@@ -139,7 +139,7 @@ class CreateContractDetailsDialog extends Component {
                                 <PublishedComponent
                                     pubRef="policyHolder.PolicyHolderInsureePicker"
                                     required
-                                    withNull
+                                    withNull={false}
                                     policyHolderId={contract?.policyHolder?.id}
                                     value={!!contractDetails.insuree && contractDetails.insuree}
                                     onChange={v => this.updateAttribute('insuree', v)}
@@ -148,7 +148,7 @@ class CreateContractDetailsDialog extends Component {
                             <Grid item className={classes.item}>
                                 <PublishedComponent
                                     pubRef="policyHolder.PolicyHolderContributionPlanBundlePicker"
-                                    withNull
+                                    withNull={false}
                                     nullLabel={formatMessage(intl, "contract", "emptyLabel")}
                                     policyHolderId={contract?.policyHolder?.id}
                                     value={!!contractDetails.contributionPlanBundle && contractDetails.contributionPlanBundle}

--- a/src/dialogs/UpdateContractDetailsDialog.js
+++ b/src/dialogs/UpdateContractDetailsDialog.js
@@ -149,7 +149,7 @@ class CreateContractDetailsDialog extends Component {
                                 <PublishedComponent
                                     pubRef="policyHolder.PolicyHolderInsureePicker"
                                     required
-                                    withNull
+                                    withNull={false}
                                     policyHolderId={contract?.policyHolder?.id}
                                     value={!!contractDetails.insuree && contractDetails.insuree}
                                     readOnly
@@ -158,7 +158,7 @@ class CreateContractDetailsDialog extends Component {
                             <Grid item className={classes.item}>
                                 <PublishedComponent
                                     pubRef="policyHolder.PolicyHolderContributionPlanBundlePicker"
-                                    withNull
+                                    withNull={false}
                                     nullLabel={formatMessage(intl, "contract", "emptyLabel")}
                                     policyHolderId={contract?.policyHolder?.id}
                                     value={!!contractDetails.contributionPlanBundle && contractDetails.contributionPlanBundle}


### PR DESCRIPTION
OP-1725

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.