### PR TITLE
OP-1806: fix calendar picker to allow selecting future dates

### DIFF
--- a/src/components/ContractHeadPanel.js
+++ b/src/components/ContractHeadPanel.js
@@ -283,7 +283,7 @@ class ContractHeadPanel extends FormPanel {
               value={!!edited && !!edited.dateValidFrom && edited.dateValidFrom}
               onChange={(v) => this.updateAttribute("dateValidFrom", v)}
               readOnly={readOnlyFields.includes("dateValidFrom") || isAmendment}
-              // NOTE: maxDate cannot be passed if endDate does not exist.
+              // NOTE: maxDate cannot be passed if dateValidTo does not exist.
               // Passing any other falsy value will block months manipulation.
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...(edited.dateValidTo ? { maxDate: edited.dateValidTo } : null)}
@@ -298,7 +298,7 @@ class ContractHeadPanel extends FormPanel {
               value={!!edited && !!edited.dateValidTo && edited.dateValidTo}
               onChange={(v) => this.updateAttribute("dateValidTo", v)}
               readOnly={readOnlyFields.includes("dateValidTo")}
-              // NOTE: minDate cannot be passed if startDate does not exist.
+              // NOTE: minDate cannot be passed if dateValidFrom does not exist.
               // Passing any other falsy value will block months manipulation.
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...(edited.dateValidFrom ? { minDate: edited.dateValidFrom } : null)}

--- a/src/components/ContractHeadPanel.js
+++ b/src/components/ContractHeadPanel.js
@@ -280,10 +280,13 @@ class ContractHeadPanel extends FormPanel {
               module="contract"
               label="dateValidFrom"
               required
-              maxDate={!!edited && !!edited.dateValidTo && edited.dateValidTo}
               value={!!edited && !!edited.dateValidFrom && edited.dateValidFrom}
               onChange={(v) => this.updateAttribute("dateValidFrom", v)}
               readOnly={readOnlyFields.includes("dateValidFrom") || isAmendment}
+              // NOTE: maxDate cannot be passed if endDate does not exist.
+              // Passing any other falsy value will block months manipulation.
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...(edited.dateValidTo ? { maxDate: edited.dateValidTo } : null)}
             />
           </Grid>
           <Grid item xs={2} className={classes.item}>
@@ -292,12 +295,13 @@ class ContractHeadPanel extends FormPanel {
               module="contract"
               label="dateValidTo"
               required
-              minDate={
-                !!edited && !!edited.dateValidFrom && edited.dateValidFrom
-              }
               value={!!edited && !!edited.dateValidTo && edited.dateValidTo}
               onChange={(v) => this.updateAttribute("dateValidTo", v)}
               readOnly={readOnlyFields.includes("dateValidTo")}
+              // NOTE: minDate cannot be passed if startDate does not exist.
+              // Passing any other falsy value will block months manipulation.
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...(edited.dateValidFrom ? { minDate: edited.dateValidFrom } : null)}
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
[OP-1806](https://openimis.atlassian.net/browse/OP-1806)

Changes:
- Resolved issues with calendar pickers to ensure users can select a start date in the future and navigate through months and years seamlessly. Additionally, enforced validation to prevent the start date from being set after the end date and vice versa.

[OP-1806]: https://openimis.atlassian.net/browse/OP-1806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ