### PR TITLE
OP-1908: display counter sign for contract

### DIFF
--- a/src/components/ContractForm.js
+++ b/src/components/ContractForm.js
@@ -38,8 +38,8 @@ const styles = theme => ({
     fab: theme.fab,
     counterFab: {
         position: 'fixed',
-        bottom: theme.spacing(11),
-        right: theme.spacing(2),
+        bottom: theme.spacing(18),
+        right: theme.spacing(1),
         zIndex: 1200
     }
 });
@@ -221,7 +221,7 @@ class ContractForm extends Component {
                 {rights.includes(RIGHT_POLICYHOLDERCONTRACT_APPROVE) && this.isApprovable() && !this.state.isDirty && (
                     <Tooltip title={formatMessage(intl, "contract", "counterButton.tooltip")} placement="left">
                         <div className={classes.counterFab}>
-                            <Fab color="primary" size="small" onClick={() => counter(this.state.contract)}>
+                            <Fab color="primary" size="normal" onClick={() => counter(this.state.contract)}>
                                 <CloseIcon/>
                             </Fab>
                         </div>


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OP-1908

Changes:
- counter button is displayed on the left tooltip menu

How was it tested?
After opening a contract with "negotiable" status and user had rights to approve contacts the button was displayed correctly and it worked, countering the contract.
![Screenshot from 2024-10-08 15-27-41](https://github.com/user-attachments/assets/b12d0e37-ec93-4399-ab0e-52d837b580ee)

